### PR TITLE
use "mkdir -p" instead of "mkdir" so the job does not fail if the directory exists (nextflow is running these with "bash -ue")

### DIFF
--- a/nf/subworkflows/ncbi/gnomon/chainer_wnode/main.nf
+++ b/nf/subworkflows/ncbi/gnomon/chainer_wnode/main.nf
@@ -121,9 +121,9 @@ process run_chainer {
     # with the same filename. We need to avoid that to be able to stage
     # the output files for gpx_make_outputs. We add the job file numeric
     # extension as a prefix to the filename.
-    mkdir interim
+    mkdir -p interim
     chainer_wnode $params -start-job-id \$start_job_id  -workers 32 -input-jobs ${job} -O interim -nogenbank -lds2 LDS2 -evidence-denylist-manifest evidence_denylist.mft -gap-fill-allowlist-manifest gap_fill_allowlist.mft -param ${hmm_params} -scaffolds-manifest scaffolds.mft -trusted-genes-manifest trusted_genes.mft
-    mkdir output
+    mkdir -p output
     for f in interim/*; do
         if [ -f \$f ]; then
             mv \$f output/\${extension}_\$(basename \$f)

--- a/nf/subworkflows/ncbi/gnomon/gnomon_wnode/main.nf
+++ b/nf/subworkflows/ncbi/gnomon/gnomon_wnode/main.nf
@@ -96,7 +96,7 @@ process annot {
 
     lds2=indexed_lds
     if [ -n "$softmask" ]; then
-        mkdir sm_src
+        mkdir -p sm_src
         mv $softmask ./sm_src/
         lds2_indexer -source ./sm_src/ -db softmask_lds2
         lds2+=",softmask_lds2"
@@ -114,9 +114,9 @@ process annot {
     # with the same filename. We need to avoid that to be able to stage
     # the output files for gpx_make_outputs. We add the job file numeric
     # extension as a prefix to the filename.
-    mkdir interim
+    mkdir -p interim
     annot_wnode $params -nogenbank -lds2 \$lds2  -start-job-id \$start_job_id -workers \$threads -input-jobs $jobs -param $hmm_params -O interim || true
-    mkdir output
+    mkdir -p output
     for f in interim/*; do
         if [ -f \$f ]; then
             mv \$f output/\${extension}_\$(basename \$f)

--- a/nf/subworkflows/ncbi/rnaseq_short/fetch_sra_fasta/main.nf
+++ b/nf/subworkflows/ncbi/rnaseq_short/fetch_sra_fasta/main.nf
@@ -48,7 +48,7 @@ process run_fetch_sra_fasta {
     curl -o ${sra} \$output_${sra}
     fasterq-dump --skip-technical --threads 6 --split-files --seq-defline ">\\\$ac.\\\$si.\\\$ri" --fasta -O .  ./${sra}
     rm -f ${sra}
-    mkdir output
+    mkdir -p output
     mv ${sra}_1.fasta output/${sra}.1
     if [ -f ${sra}_2.fasta ]; then
         mv ${sra}_2.fasta output/${sra}.2

--- a/nf/subworkflows/ncbi/rnaseq_short/rnaseq_collapse/main.nf
+++ b/nf/subworkflows/ncbi/rnaseq_short/rnaseq_collapse/main.nf
@@ -98,9 +98,9 @@ process run_rnaseq_collapse {
     # with the same filename. We need to avoid that to be able to stage
     # the output files for gpx_make_outputs. We add the job file numeric
     # extension as a prefix to the filename.
-    mkdir interim
+    mkdir -p interim
     rnaseq_collapse $params -O interim -nogenbank -lds2 ./genome_lds -sorted-vols align.mft -scaffold-list scaffold_list.mft -sra-metadata-manifest metadata.mft -start-job-id \$start_job_id -input-jobs $job -workers \$threads
-    mkdir output
+    mkdir -p output
     for f in interim/*; do
         if [ -f \$f ]; then
             mv \$f output/\${extension}_\$(basename \$f)

--- a/nf/subworkflows/ncbi/shared/diamond/main.nf
+++ b/nf/subworkflows/ncbi/shared/diamond/main.nf
@@ -83,8 +83,8 @@ process run_diamond_egap {
     prime_cache -cache ./asncache/ -ifmt asnb-seq-entry  -i ${gnomon_prot_asn} -oseq-ids /dev/null -split-sequences
     prime_cache -cache ./asncache/ -ifmt asnb-seq-entry  -i ${swiss_prot_asn} -oseq-ids /dev/null -split-sequences
 
-    mkdir ./output
-    mkdir ./work
+    mkdir -p ./output
+    mkdir -p ./work
 
     echo  ${params}
     echo "${gnomon_prot_ids.join('\n')}" > query.mft


### PR DESCRIPTION
use `mkdir -p` instead of `mkdir` so the job does not fail if the directory exists (nextflow is running these with `bash -ue`)

See issue #55