### PR TITLE
Make the local SRA read cache relocatable

### DIFF
--- a/ui/egapx.py
+++ b/ui/egapx.py
@@ -2360,7 +2360,24 @@ def read_cache() -> tuple[dict[str, list[str]], dict[str, list[str]], dict[str, 
         if not g_sra_to_file_map:
             sra_runs_file = os.path.join(cache_dir, SRA_DOWNLOAD_FOLDER, SRA_RUNS_FILE)
             if os.path.isfile(sra_runs_file):
-                g_sra_to_file_map = yaml.safe_load(open(sra_runs_file, 'r'))
+                raw_sra_to_file_map = yaml.safe_load(open(sra_runs_file, 'r')) or {}
+                # Stored paths are absolute and point at the location where the cache
+                # was created. When the cache directory is relocated (for example, moved
+                # between jobs), those paths no longer exist. Rebase each cached read
+                # file onto the current cache location by file name so the cache is
+                # relocatable; fall back to the stored path only if the rebased file
+                # is absent.
+                sra_files_dir = os.path.join(cache_dir, SRA_DOWNLOAD_FOLDER)
+                g_sra_to_file_map = {}
+                for run_accession, file_list in raw_sra_to_file_map.items():
+                    rebased_files = []
+                    for file_path in file_list:
+                        candidate = os.path.join(sra_files_dir, os.path.basename(file_path))
+                        if os.path.isfile(candidate):
+                            rebased_files.append(candidate)
+                        elif os.path.isfile(file_path):
+                            rebased_files.append(file_path)
+                    g_sra_to_file_map[run_accession] = rebased_files
         if not g_query_to_accessions_map:
             sra_queries_file = os.path.join(cache_dir, SRA_DOWNLOAD_FOLDER, SRA_QUERIES_FILE)
             if os.path.isfile(sra_queries_file):


### PR DESCRIPTION
  Closes #257.
  
  `read_cache()` previously returned the absolute read-file paths from `runs.yaml` as-is, so a cache used from a different path than where it was created (e.g. a Galaxy `directory` dataset handed between jobs) resolved to files that no longer exist, and the STAR step received no reads. This change resolves each cached read path against the current cache location (`<cache>/sra_dir/<basename>`) when loading `runs.yaml`, falling back to the stored path only if the rebased file is absent. Same-location runs behave exactly as before.
    
  **Testing:** built into our augmented Galaxy EGAPx container and run through a prepare→execute Galaxy workflow (cache produced by one job, consumed by another). Before the change `run_star` failed with "No such file or directory"; after it, STAR receives the reads and the run proceeds. Happy to adjust naming/structure to match your conventions.